### PR TITLE
Support async functions natively

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: ["push", "pull_request"]
+on: ["push"]
 
 jobs:
   linting:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.9-slim-bullseye
 
 # Create folder system for all the code to go
 ENV APP_DIR dobles

--- a/dobles/allowance.py
+++ b/dobles/allowance.py
@@ -70,11 +70,9 @@ class Allowance(object):
         self._custom_matcher = None
         self._is_satisfied = True
         self._call_counter = CallCountAccumulator()
-        self._is_async = inspect.iscoroutinefunction(
-            target.get_attr(method_name).object
-        )
 
-        if self._is_async:
+        self.is_async: bool = target.is_attr_async(method_name)
+        if self.is_async:
             self._return_value = _async_return_value
         else:
             self._return_value = lambda *args, **kwargs: None
@@ -94,9 +92,7 @@ class Allowance(object):
         async def async_proxy_exception(*proxy_args, **proxy_kwargs):
             raise exception
 
-        self._return_value = (
-            async_proxy_exception if self._is_async else proxy_exception
-        )
+        self._return_value = async_proxy_exception if self.is_async else proxy_exception
         return self
 
     def and_return(self, *return_values):
@@ -131,11 +127,11 @@ class Allowance(object):
 
         if not check_func_takes_args(return_value):
             self._return_value = lambda *args, **kwargs: _maybe_async(
-                self._is_async,
+                self.is_async,
                 return_value(),
             )
         else:
-            self._return_value = _maybe_async(self._is_async, return_value)
+            self._return_value = _maybe_async(self.is_async, return_value)
 
         return self
 

--- a/dobles/allowance.py
+++ b/dobles/allowance.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+from typing import Any
 
 import dobles.lifecycle
 from dobles.call_count_accumulator import CallCountAccumulator
@@ -9,17 +10,26 @@ from dobles.verification import verify_arguments
 _any = object()
 
 
-def _get_future():
-    try:
-        from concurrent.futures import Future
-    except ImportError:
-        try:
-            from tornado.concurrent import Future
-        except ImportError:
-            raise ImportError(
-                "Error Importing Future, Could not find concurrent.futures or tornado.concurrent",
-            )
-    return Future()
+async def _async_return_value(*args, **kwargs):
+    return None
+
+
+def _maybe_async(is_async: bool, return_value: Any):
+    if is_async:
+        return make_it_async(return_value)
+    return return_value
+
+
+def make_it_async(
+    return_value=None,
+    exception=None,
+):
+    async def inner(*args, **kwargs):
+        if exception:
+            raise exception
+        return return_value
+
+    return inner()
 
 
 def verify_count_is_non_negative(func):
@@ -60,8 +70,14 @@ class Allowance(object):
         self._custom_matcher = None
         self._is_satisfied = True
         self._call_counter = CallCountAccumulator()
+        self._is_async = inspect.iscoroutinefunction(
+            target.get_attr(method_name).object
+        )
 
-        self._return_value = lambda *args, **kwargs: None
+        if self._is_async:
+            self._return_value = _async_return_value
+        else:
+            self._return_value = lambda *args, **kwargs: None
 
     def and_raise(self, exception, *args, **kwargs):
         """Causes the double to raise the provided exception when called.
@@ -75,29 +91,13 @@ class Allowance(object):
         def proxy_exception(*proxy_args, **proxy_kwargs):
             raise exception
 
-        self._return_value = proxy_exception
+        async def async_proxy_exception(*proxy_args, **proxy_kwargs):
+            raise exception
+
+        self._return_value = (
+            async_proxy_exception if self._is_async else proxy_exception
+        )
         return self
-
-    def and_raise_future(self, exception):
-        """Similar to `and_raise` but the doubled method returns a future.
-
-        :param Exception exception: The exception to raise.
-        """
-        future = _get_future()
-        future.set_exception(exception)
-        return self.and_return(future)
-
-    def and_return_future(self, *return_values):
-        """Similar to `and_return` but the doubled method returns a future.
-
-        :param object return_values: The values the double will return when called,
-        """
-        futures = []
-        for value in return_values:
-            future = _get_future()
-            future.set_result(value)
-            futures.append(future)
-        return self.and_return(*futures)
 
     def and_return(self, *return_values):
         """Set a return value for an allowance
@@ -128,10 +128,14 @@ class Allowance(object):
         :param return_value: A callable that will be invoked to determine the double's return value.
         :type return_value: any callable object
         """
+
         if not check_func_takes_args(return_value):
-            self._return_value = lambda *args, **kwargs: return_value()
+            self._return_value = lambda *args, **kwargs: _maybe_async(
+                self._is_async,
+                return_value(),
+            )
         else:
-            self._return_value = return_value
+            self._return_value = _maybe_async(self._is_async, return_value)
 
         return self
 

--- a/dobles/proxy_method.py
+++ b/dobles/proxy_method.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from inspect import isbuiltin
+from typing import Set
 
 from dobles.allowance import build_argument_repr_string
 from dobles.exceptions import UnallowedMethodCallError
@@ -8,6 +9,15 @@ from dobles.proxy_property import ProxyProperty
 
 def double_name(name):
     return "double_of_" + name
+
+
+_ATTR_METHODS: Set[str] = {
+    "__call__",
+    "__aenter__",
+    "__aexit__",
+    "__enter__",
+    "__exit__",
+}
 
 
 def _restore__new__(target, original_method):
@@ -122,7 +132,7 @@ class ProxyMethod(object):
             # TODO: Could there ever have been a value here that needs to be restored?
             del self._target.obj.__dict__[self._method_name]
 
-        if self._method_name in ["__call__", "__enter__", "__exit__"]:
+        if self._method_name in _ATTR_METHODS:
             self._target.restore_attr(self._method_name)
 
     def _capture_original_method(self):
@@ -145,7 +155,7 @@ class ProxyMethod(object):
         else:
             self._target.obj.__dict__[self._method_name] = self
 
-        if self._method_name in ["__call__", "__enter__", "__exit__"]:
+        if self._method_name in _ATTR_METHODS:
             self._target.hijack_attr(self._method_name)
 
     def _raise_exception(self, args, kwargs):

--- a/dobles/proxy_method.py
+++ b/dobles/proxy_method.py
@@ -13,6 +13,7 @@ def double_name(name):
 
 _ATTR_METHODS: Set[str] = {
     "__call__",
+    "__wrapped__",
     "__aenter__",
     "__aexit__",
     "__enter__",

--- a/dobles/target.py
+++ b/dobles/target.py
@@ -1,5 +1,12 @@
 from collections import namedtuple
-from inspect import classify_class_attrs, getmembers, isclass, ismodule
+from inspect import (
+    classify_class_attrs,
+    getmembers,
+    isclass,
+    iscoroutinefunction,
+    ismodule,
+)
+from typing import Any
 
 from dobles.object_double import ObjectDouble
 from dobles.verification import is_callable
@@ -160,3 +167,16 @@ class Target(object):
     def get_attr(self, method_name):
         """Get attribute from the target object"""
         return self.attrs.get(method_name) or self.get_callable_attr(method_name)
+
+    def is_attr_async(self, name: str) -> bool:
+        object: Any = self.get_attr(name).object
+        object = getattr(object, "_dobles_target_method", object)
+
+        if iscoroutinefunction(object):
+            return True
+
+        for i in ("__call__", "__wrapped__"):
+            if hasattr(object, i):
+                return iscoroutinefunction(getattr(object, i))
+
+        return False

--- a/dobles/testing.py
+++ b/dobles/testing.py
@@ -18,12 +18,15 @@ class AsyncCallable:
         return self.value
 
 
+async def async_function():
+    return "dummy result"
+
+
 class AsyncUser:
     """An importable dummy class used for testing purposes."""
 
     class_attribute = "foo"
-    # TODO: HOW TO DO AN ASYNC LAMBDA
-    callable_class_attribute = classmethod(lambda cls: "dummy result")
+    callable_class_attribute = async_function
     arbitrary_callable = AsyncCallable("ArbitraryCallable Value")
 
     def __init__(self, name, age):
@@ -88,7 +91,7 @@ class User:
         self.callable_instance_attribute = lambda: "dummy result"
 
     @staticmethod
-    async def static_method(arg):
+    def static_method(arg):
         return "static_method return value: {}".format(arg)
 
     @classmethod

--- a/dobles/testing.py
+++ b/dobles/testing.py
@@ -10,6 +10,71 @@ class ArbitraryCallable:
         return self.value
 
 
+class AsyncCallable:
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+class AsyncUser:
+    """An importable dummy class used for testing purposes."""
+
+    class_attribute = "foo"
+    # TODO: HOW TO DO AN ASYNC LAMBDA
+    callable_class_attribute = classmethod(lambda cls: "dummy result")
+    arbitrary_callable = AsyncCallable("ArbitraryCallable Value")
+
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+        self.callable_instance_attribute = lambda: "dummy result"
+
+    @staticmethod
+    async def static_method(arg):
+        return "static_method return value: {}".format(arg)
+
+    @classmethod
+    async def class_method(cls, arg):
+        return "class_method return value: {}".format(arg)
+
+    async def get_name(self):
+        return self.name
+
+    async def instance_method(self):
+        return "instance_method return value"
+
+    async def method_with_varargs(self, *args):
+        return "method_with_varargs return value"
+
+    async def method_with_default_args(self, foo, bar="baz"):
+        return "method_with_default_args return value"
+
+    async def method_with_varkwargs(self, **kwargs):
+        return "method_with_varkwargs return value"
+
+    async def method_with_positional_arguments(self, foo):
+        return "method_with_positional_arguments return value"
+
+    async def method_with_doc(self):
+        """A basic method of User to illustrate existence of a docstring"""
+        return
+
+    @property
+    async def some_property(self):
+        return "some_property return value"
+
+    async def __call__(self, *args):
+        return "user was called"
+
+    async def __enter__(self):
+        return self
+
+    async def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
 class User:
     """An importable dummy class used for testing purposes."""
 
@@ -23,7 +88,7 @@ class User:
         self.callable_instance_attribute = lambda: "dummy result"
 
     @staticmethod
-    def static_method(arg):
+    async def static_method(arg):
         return "static_method return value: {}".format(arg)
 
     @classmethod

--- a/dobles/testing.py
+++ b/dobles/testing.py
@@ -67,10 +67,10 @@ class AsyncUser:
     async def __call__(self, *args):
         return "user was called"
 
-    async def __enter__(self):
+    async def __aenter__(self):
         return self
 
-    async def __exit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback):
         pass
 
 

--- a/dobles/testing.py
+++ b/dobles/testing.py
@@ -10,15 +10,15 @@ class ArbitraryCallable:
         return self.value
 
 
-class AsyncCallable:
+class ArbitraryAsyncCallable:
     def __init__(self, value):
         self.value = value
 
-    def __call__(self):
+    async def __call__(self):
         return self.value
 
 
-async def async_function():
+async def async_function(*args, **kwargs):
     return "dummy result"
 
 
@@ -26,13 +26,13 @@ class AsyncUser:
     """An importable dummy class used for testing purposes."""
 
     class_attribute = "foo"
-    callable_class_attribute = async_function
-    arbitrary_callable = AsyncCallable("ArbitraryCallable Value")
+    callable_class_attribute = classmethod(async_function)
+    arbitrary_callable = ArbitraryAsyncCallable("ArbitraryCallable Value")
 
     def __init__(self, name, age):
         self.name = name
         self.age = age
-        self.callable_instance_attribute = lambda: "dummy result"
+        self.callable_instance_attribute = async_function
 
     @staticmethod
     async def static_method(arg):
@@ -63,10 +63,6 @@ class AsyncUser:
     async def method_with_doc(self):
         """A basic method of User to illustrate existence of a docstring"""
         return
-
-    @property
-    async def some_property(self):
-        return "some_property return value"
 
     async def __call__(self, *args):
         return "user was called"
@@ -149,6 +145,14 @@ def top_level_function_that_creates_an_instance():
     return User("Bob Barker", 100), User("Bob Barker", 100)
 
 
+async def async_top_level_function(arg1, arg2="default"):
+    return top_level_function(arg1, arg2)
+
+
+async def async_top_level_function_that_creates_an_instance():
+    return AsyncUser("Bob Barker", 100), AsyncUser("Bob Barker", 100)
+
+
 class ClassWithGetAttr(object):
     def __init__(self):
         self.attr = "attr"
@@ -165,8 +169,17 @@ class Callable(object):
         return arg1
 
 
+class AsyncCallable(object):
+    async def __call__(self, arg1):
+        return arg1
+
+
 def return_callable(func):
     return Callable()
+
+
+def return_async_callable(func):
+    return AsyncCallable()
 
 
 def decorate_me(func):
@@ -186,10 +199,19 @@ def decorated_function(arg1):
     return arg1
 
 
+@return_async_callable
+def async_decorated_function_callable(arg1):
+    return arg1
+
+
 callable_variable = Callable()
+async_callable_variable = AsyncCallable()
 
 class_method = User.class_method
 instance_method = User("Bob", 25).get_name
+
+async_class_method = AsyncUser.class_method
+async_instance_method = AsyncUser("Bob", 25).get_name
 
 
 class NeverEquals(object):

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,14 +13,17 @@ files = [
 
 [[package]]
 name = "babel"
-version = "2.13.0"
+version = "2.13.1"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Babel-2.13.0-py3-none-any.whl", hash = "sha256:fbfcae1575ff78e26c7449136f1abbefc3c13ce542eeb13d43d50d8b047216ec"},
-    {file = "Babel-2.13.0.tar.gz", hash = "sha256:04c3e2d28d2b7681644508f836be388ae49e0cfe91465095340395b60d00f210"},
+    {file = "Babel-2.13.1-py3-none-any.whl", hash = "sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"},
+    {file = "Babel-2.13.1.tar.gz", hash = "sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900"},
 ]
+
+[package.dependencies]
+setuptools = {version = "*", markers = "python_version >= \"3.12\""}
 
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
@@ -84,101 +87,101 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.3.0"
+version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.3.0.tar.gz", hash = "sha256:63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:effe5406c9bd748a871dbcaf3ac69167c38d72db8c9baf3ff954c344f31c4cbe"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4162918ef3098851fcd8a628bf9b6a98d10c380725df9e04caf5ca6dd48c847a"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0570d21da019941634a531444364f2482e8db0b3425fcd5ac0c36565a64142c8"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5707a746c6083a3a74b46b3a631d78d129edab06195a92a8ece755aac25a3f3d"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:278c296c6f96fa686d74eb449ea1697f3c03dc28b75f873b65b5201806346a69"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a4b71f4d1765639372a3b32d2638197f5cd5221b19531f9245fcc9ee62d38f56"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5969baeaea61c97efa706b9b107dcba02784b1601c74ac84f2a532ea079403e"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3f93dab657839dfa61025056606600a11d0b696d79386f974e459a3fbc568ec"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:db756e48f9c5c607b5e33dd36b1d5872d0422e960145b08ab0ec7fd420e9d649"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:232ac332403e37e4a03d209a3f92ed9071f7d3dbda70e2a5e9cff1c4ba9f0678"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:e5c1502d4ace69a179305abb3f0bb6141cbe4714bc9b31d427329a95acfc8bdd"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:2502dd2a736c879c0f0d3e2161e74d9907231e25d35794584b1ca5284e43f596"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23e8565ab7ff33218530bc817922fae827420f143479b753104ab801145b1d5b"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-win32.whl", hash = "sha256:1872d01ac8c618a8da634e232f24793883d6e456a66593135aeafe3784b0848d"},
-    {file = "charset_normalizer-3.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:557b21a44ceac6c6b9773bc65aa1b4cc3e248a5ad2f5b914b91579a32e22204d"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d7eff0f27edc5afa9e405f7165f85a6d782d308f3b6b9d96016c010597958e63"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a685067d05e46641d5d1623d7c7fdf15a357546cbb2f71b0ebde91b175ffc3e"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d3d5b7db9ed8a2b11a774db2bbea7ba1884430a205dbd54a32d61d7c2a190fa"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2935ffc78db9645cb2086c2f8f4cfd23d9b73cc0dc80334bc30aac6f03f68f8c"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9fe359b2e3a7729010060fbca442ca225280c16e923b37db0e955ac2a2b72a05"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380c4bde80bce25c6e4f77b19386f5ec9db230df9f2f2ac1e5ad7af2caa70459"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0d1e3732768fecb052d90d62b220af62ead5748ac51ef61e7b32c266cac9293"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b2919306936ac6efb3aed1fbf81039f7087ddadb3160882a57ee2ff74fd2382"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f8888e31e3a85943743f8fc15e71536bda1c81d5aa36d014a3c0c44481d7db6e"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:82eb849f085624f6a607538ee7b83a6d8126df6d2f7d3b319cb837b289123078"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7b8b8bf1189b3ba9b8de5c8db4d541b406611a71a955bbbd7385bbc45fcb786c"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:5adf257bd58c1b8632046bbe43ee38c04e1038e9d37de9c57a94d6bd6ce5da34"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c350354efb159b8767a6244c166f66e67506e06c8924ed74669b2c70bc8735b1"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-win32.whl", hash = "sha256:02af06682e3590ab952599fbadac535ede5d60d78848e555aa58d0c0abbde786"},
-    {file = "charset_normalizer-3.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:86d1f65ac145e2c9ed71d8ffb1905e9bba3a91ae29ba55b4c46ae6fc31d7c0d4"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:3b447982ad46348c02cb90d230b75ac34e9886273df3a93eec0539308a6296d7"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:abf0d9f45ea5fb95051c8bfe43cb40cda383772f7e5023a83cc481ca2604d74e"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b09719a17a2301178fac4470d54b1680b18a5048b481cb8890e1ef820cb80455"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b3d9b48ee6e3967b7901c052b670c7dda6deb812c309439adaffdec55c6d7b78"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:edfe077ab09442d4ef3c52cb1f9dab89bff02f4524afc0acf2d46be17dc479f5"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3debd1150027933210c2fc321527c2299118aa929c2f5a0a80ab6953e3bd1908"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86f63face3a527284f7bb8a9d4f78988e3c06823f7bea2bd6f0e0e9298ca0403"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:24817cb02cbef7cd499f7c9a2735286b4782bd47a5b3516a0e84c50eab44b98e"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c71f16da1ed8949774ef79f4a0260d28b83b3a50c6576f8f4f0288d109777989"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:9cf3126b85822c4e53aa28c7ec9869b924d6fcfb76e77a45c44b83d91afd74f9"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:b3b2316b25644b23b54a6f6401074cebcecd1244c0b8e80111c9a3f1c8e83d65"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:03680bb39035fbcffe828eae9c3f8afc0428c91d38e7d61aa992ef7a59fb120e"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cc152c5dd831641e995764f9f0b6589519f6f5123258ccaca8c6d34572fefa8"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-win32.whl", hash = "sha256:b8f3307af845803fb0b060ab76cf6dd3a13adc15b6b451f54281d25911eb92df"},
-    {file = "charset_normalizer-3.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:8eaf82f0eccd1505cf39a45a6bd0a8cf1c70dcfc30dba338207a969d91b965c0"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dc45229747b67ffc441b3de2f3ae5e62877a282ea828a5bdb67883c4ee4a8810"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f4a0033ce9a76e391542c182f0d48d084855b5fcba5010f707c8e8c34663d77"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ada214c6fa40f8d800e575de6b91a40d0548139e5dc457d2ebb61470abf50186"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1121de0e9d6e6ca08289583d7491e7fcb18a439305b34a30b20d8215922d43c"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1063da2c85b95f2d1a430f1c33b55c9c17ffaf5e612e10aeaad641c55a9e2b9d"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70f1d09c0d7748b73290b29219e854b3207aea922f839437870d8cc2168e31cc"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:250c9eb0f4600361dd80d46112213dff2286231d92d3e52af1e5a6083d10cad9"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:750b446b2ffce1739e8578576092179160f6d26bd5e23eb1789c4d64d5af7dc7"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:fc52b79d83a3fe3a360902d3f5d79073a993597d48114c29485e9431092905d8"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:588245972aca710b5b68802c8cad9edaa98589b1b42ad2b53accd6910dad3545"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e39c7eb31e3f5b1f88caff88bcff1b7f8334975b46f6ac6e9fc725d829bc35d4"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-win32.whl", hash = "sha256:abecce40dfebbfa6abf8e324e1860092eeca6f7375c8c4e655a8afb61af58f2c"},
-    {file = "charset_normalizer-3.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:24a91a981f185721542a0b7c92e9054b7ab4fea0508a795846bc5b0abf8118d4"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:67b8cc9574bb518ec76dc8e705d4c39ae78bb96237cb533edac149352c1f39fe"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac71b2977fb90c35d41c9453116e283fac47bb9096ad917b8819ca8b943abecd"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3ae38d325b512f63f8da31f826e6cb6c367336f95e418137286ba362925c877e"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:542da1178c1c6af8873e143910e2269add130a299c9106eef2594e15dae5e482"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30a85aed0b864ac88309b7d94be09f6046c834ef60762a8833b660139cfbad13"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aae32c93e0f64469f74ccc730a7cb21c7610af3a775157e50bbd38f816536b38"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15b26ddf78d57f1d143bdf32e820fd8935d36abe8a25eb9ec0b5a71c82eb3895"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f5d10bae5d78e4551b7be7a9b29643a95aded9d0f602aa2ba584f0388e7a557"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:249c6470a2b60935bafd1d1d13cd613f8cd8388d53461c67397ee6a0f5dce741"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:c5a74c359b2d47d26cdbbc7845e9662d6b08a1e915eb015d044729e92e7050b7"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:b5bcf60a228acae568e9911f410f9d9e0d43197d030ae5799e20dca8df588287"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:187d18082694a29005ba2944c882344b6748d5be69e3a89bf3cc9d878e548d5a"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:81bf654678e575403736b85ba3a7867e31c2c30a69bc57fe88e3ace52fb17b89"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-win32.whl", hash = "sha256:85a32721ddde63c9df9ebb0d2045b9691d9750cb139c161c80e500d210f5e26e"},
-    {file = "charset_normalizer-3.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:468d2a840567b13a590e67dd276c570f8de00ed767ecc611994c301d0f8c014f"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e0fc42822278451bc13a2e8626cf2218ba570f27856b536e00cfa53099724828"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:09c77f964f351a7369cc343911e0df63e762e42bac24cd7d18525961c81754f4"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:12ebea541c44fdc88ccb794a13fe861cc5e35d64ed689513a5c03d05b53b7c82"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:805dfea4ca10411a5296bcc75638017215a93ffb584c9e344731eef0dcfb026a"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:96c2b49eb6a72c0e4991d62406e365d87067ca14c1a729a870d22354e6f68115"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aaf7b34c5bc56b38c931a54f7952f1ff0ae77a2e82496583b247f7c969eb1479"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:619d1c96099be5823db34fe89e2582b336b5b074a7f47f819d6b3a57ff7bdb86"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a0ac5e7015a5920cfce654c06618ec40c33e12801711da6b4258af59a8eff00a"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:93aa7eef6ee71c629b51ef873991d6911b906d7312c6e8e99790c0f33c576f89"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7966951325782121e67c81299a031f4c115615e68046f79b85856b86ebffc4cd"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:02673e456dc5ab13659f85196c534dc596d4ef260e4d86e856c3b2773ce09843"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:c2af80fb58f0f24b3f3adcb9148e6203fa67dd3f61c4af146ecad033024dde43"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:153e7b6e724761741e0974fc4dcd406d35ba70b92bfe3fedcb497226c93b9da7"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-win32.whl", hash = "sha256:d47ecf253780c90ee181d4d871cd655a789da937454045b17b5798da9393901a"},
-    {file = "charset_normalizer-3.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:d97d85fa63f315a8bdaba2af9a6a686e0eceab77b3089af45133252618e70884"},
-    {file = "charset_normalizer-3.3.0-py3-none-any.whl", hash = "sha256:e46cd37076971c1040fc8c41273a8b3e2c624ce4f2be3f5dfcb7a430c1d3acc2"},
+    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
+    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
 ]
 
 [[package]]
@@ -554,13 +557,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pycodestyle"
-version = "2.11.0"
+version = "2.11.1"
 description = "Python style guide checker"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pycodestyle-2.11.0-py2.py3-none-any.whl", hash = "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"},
-    {file = "pycodestyle-2.11.0.tar.gz", hash = "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0"},
+    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
+    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
 ]
 
 [[package]]
@@ -590,13 +593,13 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pytest"
-version = "7.4.2"
+version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
-    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
+    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
+    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
 ]
 
 [package.dependencies]
@@ -609,6 +612,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.21.1"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "requests"
@@ -630,6 +651,22 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "setuptools"
+version = "68.2.2"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-68.2.2-py3-none-any.whl", hash = "sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a"},
+    {file = "setuptools-68.2.2.tar.gz", hash = "sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "snowballstemmer"
@@ -838,13 +875,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.6"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
-    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
@@ -871,4 +908,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "4c93db9ec77ae17df9a7068cfe81368f68777fb31cda1fd7e0cd9e3674766898"
+content-hash = "45fa6dd5fed5aa8bebf3454a999d7e4df1c8535c2de56f6382d4fa99d7734710"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dobles"
-version = "2.0.0"
+version = "3.0.0"
 description = "Test dobles for Python."
 authors = ["Jimmy Cuadra <jimmy@uber.com>", "Todd Sifleet <todd@smartfast.com>"]
 maintainers = ["Todd Sifleet <todd@smartfast.com>"]
@@ -45,6 +45,7 @@ black = "23.9.1"
 optional = true
 
 [tool.poetry.group.test.dependencies]
+pytest-asyncio = "*"
 pytest = "*"
 coverage = "*"
 coveralls = "*"

--- a/test/allow_test.py
+++ b/test/allow_test.py
@@ -1,7 +1,6 @@
 import inspect
 import re
 
-import pytest
 from pytest import raises
 
 from dobles import allow, no_builtin_verification
@@ -532,38 +531,3 @@ class TestCustomMatcher(object):
         allow(self.subject).instance_method.with_args_validator(lambda x: True)
         with raises(VerifyingDoubleArgumentError):
             self.subject.instance_method("bob")
-
-
-class TestAsync(object):
-    def setup_method(self):
-        self.subject = InstanceDouble("dobles.testing.AsyncUser")
-
-    @pytest.mark.asyncio
-    async def test_and_return(self):
-        allow(self.subject).instance_method.and_return("Bob Barker")
-
-        result = await self.subject.instance_method()
-        assert result == "Bob Barker"
-
-    @pytest.mark.asyncio
-    async def test_and_return_multiple_values(self):
-        allow(self.subject).instance_method.and_return(
-            "Bob Barker",
-            "Drew Carey",
-        )
-
-        result1 = await self.subject.instance_method()
-        result2 = await self.subject.instance_method()
-        assert result1 == "Bob Barker"
-        assert result2 == "Drew Carey"
-
-    @pytest.mark.asyncio
-    async def test_and_raise(self):
-        exception = Exception("Bob Barker")
-        allow(self.subject).instance_method.and_raise(exception)
-
-        future = self.subject.instance_method()
-        with raises(Exception) as e:
-            await future
-
-        assert e.value == exception

--- a/test/allow_test.py
+++ b/test/allow_test.py
@@ -1,6 +1,5 @@
 import inspect
 import re
-import sys
 
 import pytest
 from pytest import raises
@@ -77,9 +76,6 @@ class TestBasicAllowance(object):
 
         assert subject.method_with_doc.__name__ == "method_with_doc"
 
-    @pytest.mark.skipif(
-        sys.version_info <= (3, 3), reason="requires Python 3.3 or higher"
-    )
     def test_proxies_can_be_inspected(self):
         subject = InstanceDouble("dobles.testing.User")
         allow(subject).instance_method
@@ -540,30 +536,34 @@ class TestCustomMatcher(object):
 
 class TestAsync(object):
     def setup_method(self):
-        self.subject = InstanceDouble("dobles.testing.User")
+        self.subject = InstanceDouble("dobles.testing.AsyncUser")
 
-    def test_and_return_future(self):
-        allow(self.subject).instance_method.and_return_future("Bob Barker")
+    @pytest.mark.asyncio
+    async def test_and_return(self):
+        allow(self.subject).instance_method.and_return("Bob Barker")
 
-        result = self.subject.instance_method()
-        assert result.result() == "Bob Barker"
+        result = await self.subject.instance_method()
+        assert result == "Bob Barker"
 
-    def test_and_return_future_multiple_values(self):
-        allow(self.subject).instance_method.and_return_future(
-            "Bob Barker", "Drew Carey"
+    @pytest.mark.asyncio
+    async def test_and_return_multiple_values(self):
+        allow(self.subject).instance_method.and_return(
+            "Bob Barker",
+            "Drew Carey",
         )
 
-        result1 = self.subject.instance_method()
-        result2 = self.subject.instance_method()
-        assert result1.result() == "Bob Barker"
-        assert result2.result() == "Drew Carey"
+        result1 = await self.subject.instance_method()
+        result2 = await self.subject.instance_method()
+        assert result1 == "Bob Barker"
+        assert result2 == "Drew Carey"
 
-    def test_and_raise_future(self):
+    @pytest.mark.asyncio
+    async def test_and_raise(self):
         exception = Exception("Bob Barker")
-        allow(self.subject).instance_method.and_raise_future(exception)
+        allow(self.subject).instance_method.and_raise(exception)
 
-        result = self.subject.instance_method()
+        future = self.subject.instance_method()
         with raises(Exception) as e:
-            result.result()
+            await future
 
         assert e.value == exception

--- a/test/async_allow_test.py
+++ b/test/async_allow_test.py
@@ -1,0 +1,595 @@
+import inspect
+import re
+
+import pytest
+from pytest import raises
+
+from dobles import allow, no_builtin_verification
+from dobles.exceptions import (
+    MockExpectationError,
+    UnallowedMethodCallError,
+    VerifyingDoubleArgumentError,
+)
+from dobles.instance_double import InstanceDouble
+from dobles.lifecycle import teardown
+from dobles.testing import AlwaysEquals, NeverEquals
+
+
+class UserDefinedException(Exception):
+    pass
+
+
+class TestBasicAllowance(object):
+    @pytest.mark.asyncio
+    async def test_allows_method_calls_on_dobles(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method
+
+        assert (await subject.instance_method()) is None
+
+    @pytest.mark.asyncio
+    async def test_raises_on_undefined_attribute_access(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        with raises(AttributeError):
+            subject.instance_method
+
+    @pytest.mark.asyncio
+    async def test_raises_if_called_with_args_that_do_not_match_signature(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+        allow(subject).instance_method
+
+        with raises(VerifyingDoubleArgumentError):
+            await subject.instance_method("bar")
+
+    @pytest.mark.asyncio
+    async def test_skip_builtin_verification_does_not_affect_non_builtins(self):
+        with no_builtin_verification():
+            subject = InstanceDouble("dobles.testing.AsyncUser")
+            allow(subject).instance_method
+
+            with raises(VerifyingDoubleArgumentError):
+                await subject.instance_method("bar")
+
+    @pytest.mark.asyncio
+    async def test_objects_with_custom__eq__method_one(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+        allow(subject).method_with_positional_arguments.with_args(NeverEquals())
+
+        await subject.method_with_positional_arguments(AlwaysEquals())
+
+    @pytest.mark.asyncio
+    async def test_objects_with_custom__eq__method_two(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+        allow(subject).method_with_positional_arguments.with_args(AlwaysEquals())
+
+        await subject.method_with_positional_arguments(NeverEquals())
+
+    @pytest.mark.asyncio
+    async def test_proxies_docstring(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_doc
+
+        assert subject.method_with_doc.__doc__ == (
+            """A basic method of User to illustrate existence of a docstring"""
+        )
+
+    @pytest.mark.asyncio
+    async def test_proxies_name(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_doc
+
+        assert subject.method_with_doc.__name__ == "method_with_doc"
+
+    @pytest.mark.asyncio
+    async def test_proxies_can_be_inspected(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+        allow(subject).instance_method
+        parameters = inspect.signature(subject.instance_method).parameters
+        assert len(parameters) == 1
+
+
+class TestWithArgs(object):
+    @pytest.mark.asyncio
+    async def test__call__is_short_hand_for_with_args(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_positional_arguments("Bob").and_return("Barker")
+        assert (await subject.method_with_positional_arguments("Bob")) == "Barker"
+
+    @pytest.mark.asyncio
+    async def test_allows_any_arguments_if_none_are_specified(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_positional_arguments.and_return("bar")
+
+        assert (
+            await subject.method_with_positional_arguments("unspecified argument")
+            == "bar"
+        )
+
+    @pytest.mark.asyncio
+    async def test_allows_specification_of_arguments(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_positional_arguments.with_args("foo")
+
+        assert (await subject.method_with_positional_arguments("foo")) is None
+
+    @pytest.mark.asyncio
+    async def test_raises_if_arguments_were_specified_but_not_provided_when_called(
+        self,
+    ):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_default_args.with_args("one", bar="two")
+
+        with raises(UnallowedMethodCallError) as e:
+            await subject.method_with_default_args()
+
+        assert re.match(
+            r"Received unexpected call to 'method_with_default_args' on "
+            r"<InstanceDouble of <class '?dobles.testing.AsyncUser'?"
+            r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
+            r"  The supplied arguments \(\)"
+            r" do not match any available allowances.",
+            str(e.value),
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_if_arguments_were_specified_but_wrong_kwarg_used_when_called(
+        self,
+    ):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_default_args.with_args("one", bar="two")
+
+        with raises(UnallowedMethodCallError) as e:
+            await subject.method_with_default_args("one", bob="barker")
+
+        assert re.match(
+            r"Received unexpected call to 'method_with_default_args' on "
+            r"<InstanceDouble of <class '?dobles.testing.AsyncUser'?"
+            r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
+            r"  The supplied arguments \('one', bob='barker'\)"
+            r" do not match any available allowances.",
+            str(e.value),
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_if_method_is_called_with_wrong_arguments(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_varargs.with_args("bar")
+
+        with raises(UnallowedMethodCallError) as e:
+            await subject.method_with_varargs("baz")
+
+        assert re.match(
+            r"Received unexpected call to 'method_with_varargs' on "
+            r"<InstanceDouble of <class '?dobles.testing.AsyncUser'?"
+            r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
+            r"  The supplied arguments \('baz'\)"
+            r" do not match any available allowances.",
+            str(e.value),
+        )
+
+    @pytest.mark.asyncio
+    async def test_matches_most_specific_allowance(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).method_with_varargs.and_return("bar")
+        allow(subject).method_with_varargs.with_args("baz").and_return("blah")
+
+        assert (await subject.method_with_varargs("baz")) == "blah"
+
+
+class TestWithNoArgs(object):
+    @pytest.mark.asyncio
+    async def test_allows_call_with_no_arguments(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.with_no_args()
+
+        assert (await subject.instance_method()) is None
+
+    @pytest.mark.asyncio
+    async def test_raises_if_called_with_args(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.with_no_args()
+
+        with raises(UnallowedMethodCallError) as e:
+            await subject.instance_method("bar")
+
+        assert re.match(
+            r"Received unexpected call to 'instance_method' on "
+            r"<InstanceDouble of <class '?dobles.testing.AsyncUser'?"
+            r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
+            r"  The supplied arguments \('bar'\)"
+            r" do not match any available allowances.",
+            str(e.value),
+        )
+
+    @pytest.mark.asyncio
+    async def test_chains_with_return_values(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.with_no_args().and_return("bar")
+
+        assert (await subject.instance_method()) == "bar"
+
+
+class TestTwice(object):
+    @pytest.mark.asyncio
+    async def test_passes_when_called_twice(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.twice()
+
+        await subject.instance_method()
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_once(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.twice()
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_called_three_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.twice()
+
+        subject.instance_method()
+        subject.instance_method()
+        with raises(MockExpectationError) as e:
+            await subject.instance_method()
+        teardown()
+
+        assert re.match(
+            r"Allowed 'instance_method' to be called 2 times instead of 3 times on "
+            r"<InstanceDouble of <class 'dobles.testing.AsyncUser'> object at .+> "
+            r"with any args, but was not."
+            r" \(.*dobles/test/async_allow_test.py:\d+\)",
+            str(e.value),
+        )
+
+
+class TestOnce(object):
+    @pytest.mark.asyncio
+    async def test_passes_when_called_once(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.once()
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_called_two_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.once()
+
+        subject.instance_method()
+        with raises(MockExpectationError) as e:
+            await subject.instance_method()
+        teardown()
+
+        assert re.match(
+            r"Allowed 'instance_method' to be called 1 time instead of 2 times on "
+            r"<InstanceDouble of <class 'dobles.testing.AsyncUser'> object at .+> "
+            r"with any args, but was not."
+            r" \(.*dobles/test/async_allow_test.py:\d+\)",
+            str(e.value),
+        )
+
+
+class TestZeroTimes(object):
+    @pytest.mark.asyncio
+    async def test_passes_when_called_never(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.never()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_called_once_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.never()
+
+        with raises(MockExpectationError) as e:
+            await subject.instance_method()
+        teardown()
+
+        assert re.match(
+            r"Allowed 'instance_method' to be called 0 times instead of 1 "
+            r"time on <InstanceDouble of <class 'dobles.testing.AsyncUser'> "
+            r"object at .+> with any args, but was not."
+            r" \(.*dobles/test/async_allow_test.py:\d+\)",
+            str(e.value),
+        )
+
+
+class TestExactly(object):
+    @pytest.mark.asyncio
+    async def test_raises_if_called_with_negative_value(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        with raises(TypeError) as e:
+            allow(subject).instance_method.exactly(-1).times
+        teardown()
+
+        assert re.match(r"exactly requires one positive integer argument", str(e.value))
+
+    @pytest.mark.asyncio
+    async def test_called_with_zero(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.exactly(0).times
+
+        with raises(MockExpectationError) as e:
+            await subject.instance_method()
+        teardown()
+
+        assert re.match(
+            r"Allowed 'instance_method' to be called 0 times instead of 1 "
+            r"time on <InstanceDouble of <class 'dobles.testing.AsyncUser'> "
+            r"object at .+> with any args, but was not."
+            r" \(.*dobles/test/async_allow_test.py:\d+\)",
+            str(e.value),
+        )
+
+    @pytest.mark.asyncio
+    async def test_calls_are_chainable(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.exactly(1).time.exactly(2).times
+
+        await subject.instance_method()
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_less_than_expected_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.exactly(2).times
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_exactly_expected_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.exactly(1).times
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_called_more_than_expected_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.exactly(1).times
+
+        subject.instance_method()
+        with raises(MockExpectationError) as e:
+            await subject.instance_method()
+        teardown()
+
+        assert re.match(
+            r"Allowed 'instance_method' to be called 1 time instead of 2 times on "
+            r"<InstanceDouble of <class 'dobles.testing.AsyncUser'> object at .+> "
+            r"with any args, but was not."
+            r" \(.*dobles/test/async_allow_test.py:\d+\)",
+            str(e.value),
+        )
+
+
+class TestAtLeast(object):
+    @pytest.mark.asyncio
+    async def test_raises_if_called_with_negative_value(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        with raises(TypeError) as e:
+            allow(subject).instance_method.at_least(-1).times
+        teardown()
+
+        assert re.match(
+            r"at_least requires one positive integer argument", str(e.value)
+        )
+
+    @pytest.mark.asyncio
+    async def test_if_called_with_zero(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_least(0).times
+
+    @pytest.mark.asyncio
+    async def test_calls_are_chainable(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_least(2).times.at_least(1).times
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_less_than_at_least_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_least(2).times
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_exactly_at_least_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_least(1).times
+
+        await subject.instance_method()
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_more_than_at_least_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_least(1).times
+
+        await subject.instance_method()
+        await subject.instance_method()
+
+
+class TestAtMost(object):
+    @pytest.mark.asyncio
+    async def test_raises_if_called_with_negative_value(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        with raises(TypeError) as e:
+            allow(subject).instance_method.at_most(-1).times
+        teardown()
+
+        assert re.match(r"at_most requires one positive integer argument", str(e.value))
+
+    @pytest.mark.asyncio
+    async def test_called_with_zero(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_most(0).times
+
+    @pytest.mark.asyncio
+    async def test_calls_are_chainable(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_most(1).times.at_most(2).times
+
+        await subject.instance_method()
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_exactly_at_most_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_most(1).times
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_called_less_than_at_most_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_most(2).times
+
+        await subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_called_more_than_at_most_times(self):
+        subject = InstanceDouble("dobles.testing.AsyncUser")
+
+        allow(subject).instance_method.at_most(1).times
+
+        await subject.instance_method()
+        with raises(MockExpectationError) as e:
+            await subject.instance_method()
+        teardown()
+
+        assert re.match(
+            r"Allowed 'instance_method' to be called at most 1 time instead of 2 times on "
+            r"<InstanceDouble of <class 'dobles.testing.AsyncUser'> object at .+> "
+            r"with any args, but was not."
+            r" \(.*dobles/test/async_allow_test.py:\d+\)",
+            str(e.value),
+        )
+
+
+class TestCustomMatcher(object):
+    def setup_method(self):
+        self.subject = InstanceDouble("dobles.testing.AsyncUser")
+
+    @pytest.mark.asyncio
+    async def test_matcher_raises_an_exception(self):
+        def func():
+            raise Exception("Bob Barker")
+
+        allow(self.subject).instance_method.with_args_validator(func)
+        with raises(UnallowedMethodCallError):
+            await self.subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_no_args_returns_true(self):
+        allow(self.subject).instance_method.with_args_validator(
+            lambda: True
+        ).and_return("Bob")
+        (await self.subject.instance_method()) == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_no_args_returns_false(self):
+        allow(self.subject).instance_method.with_args_validator(lambda: False)
+        with raises(UnallowedMethodCallError):
+            await self.subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_positional_args_returns_true(self):
+        (
+            allow(self.subject)
+            .method_with_positional_arguments.with_args_validator(lambda x: True)
+            .and_return("Bob")
+        )
+        await self.subject.method_with_positional_arguments("Bob Barker") == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_positional_args_returns_false(self):
+        allow(self.subject).method_with_positional_arguments.with_args_validator(
+            lambda x: False
+        )
+        with raises(UnallowedMethodCallError):
+            self.subject.method_with_positional_arguments("Bob Barker")
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_kwargs_args_returns_false(self):
+        def func(bar=None):
+            return False
+
+        allow(self.subject).instance_method.with_args_validator(func)
+        with raises(UnallowedMethodCallError):
+            self.subject.instance_method()
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_kwargs_args_returns_true(self):
+        def func(bar=None):
+            return True
+
+        allow(self.subject).instance_method.with_args_validator(func).and_return("Bob")
+        self.subject.instance_method() == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_positional_and_kwargs_returns_true(self):
+        def func(foo, bar=None):
+            return True
+
+        allow(self.subject).method_with_default_args.with_args_validator(
+            func
+        ).and_return("Bob")
+        self.subject.method_with_default_args("bob", bar="Barker") == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_matcher_with_positional_and_kwargs_returns_false(self):
+        def func(foo, bar=None):
+            return False
+
+        allow(self.subject).method_with_default_args.with_args_validator(
+            func
+        ).and_return("Bob")
+        with raises(UnallowedMethodCallError):
+            self.subject.method_with_default_args("bob", bar="Barker")
+
+    @pytest.mark.asyncio
+    async def test_matcher_returns_true_but_args_do_not_match_call_signature(self):
+        allow(self.subject).instance_method.with_args_validator(lambda x: True)
+        with raises(VerifyingDoubleArgumentError):
+            self.subject.instance_method("bob")

--- a/test/async_allow_test.py
+++ b/test/async_allow_test.py
@@ -247,8 +247,8 @@ class TestTwice(object):
 
         allow(subject).instance_method.twice()
 
-        subject.instance_method()
-        subject.instance_method()
+        await subject.instance_method()
+        await subject.instance_method()
         with raises(MockExpectationError) as e:
             await subject.instance_method()
         teardown()
@@ -277,7 +277,7 @@ class TestOnce(object):
 
         allow(subject).instance_method.once()
 
-        subject.instance_method()
+        await subject.instance_method()
         with raises(MockExpectationError) as e:
             await subject.instance_method()
         teardown()
@@ -377,7 +377,7 @@ class TestExactly(object):
 
         allow(subject).instance_method.exactly(1).times
 
-        subject.instance_method()
+        await subject.instance_method()
         with raises(MockExpectationError) as e:
             await subject.instance_method()
         teardown()
@@ -548,7 +548,7 @@ class TestCustomMatcher(object):
             lambda x: False
         )
         with raises(UnallowedMethodCallError):
-            self.subject.method_with_positional_arguments("Bob Barker")
+            await self.subject.method_with_positional_arguments("Bob Barker")
 
     @pytest.mark.asyncio
     async def test_matcher_with_kwargs_args_returns_false(self):
@@ -557,7 +557,7 @@ class TestCustomMatcher(object):
 
         allow(self.subject).instance_method.with_args_validator(func)
         with raises(UnallowedMethodCallError):
-            self.subject.instance_method()
+            await self.subject.instance_method()
 
     @pytest.mark.asyncio
     async def test_matcher_with_kwargs_args_returns_true(self):
@@ -565,7 +565,7 @@ class TestCustomMatcher(object):
             return True
 
         allow(self.subject).instance_method.with_args_validator(func).and_return("Bob")
-        self.subject.instance_method() == "Bob"
+        await self.subject.instance_method() == "Bob"
 
     @pytest.mark.asyncio
     async def test_matcher_with_positional_and_kwargs_returns_true(self):
@@ -575,7 +575,7 @@ class TestCustomMatcher(object):
         allow(self.subject).method_with_default_args.with_args_validator(
             func
         ).and_return("Bob")
-        self.subject.method_with_default_args("bob", bar="Barker") == "Bob"
+        await self.subject.method_with_default_args("bob", bar="Barker") == "Bob"
 
     @pytest.mark.asyncio
     async def test_matcher_with_positional_and_kwargs_returns_false(self):
@@ -586,10 +586,10 @@ class TestCustomMatcher(object):
             func
         ).and_return("Bob")
         with raises(UnallowedMethodCallError):
-            self.subject.method_with_default_args("bob", bar="Barker")
+            await self.subject.method_with_default_args("bob", bar="Barker")
 
     @pytest.mark.asyncio
     async def test_matcher_returns_true_but_args_do_not_match_call_signature(self):
         allow(self.subject).instance_method.with_args_validator(lambda x: True)
         with raises(VerifyingDoubleArgumentError):
-            self.subject.instance_method("bob")
+            await self.subject.instance_method("bob")

--- a/test/async_partial_double_test.py
+++ b/test/async_partial_double_test.py
@@ -118,70 +118,70 @@ class TestAsync__call__(object):
             await allow(user).__call__.with_args(1, 2, bob="barker")
 
 
-class TestAsync__enter__(object):
+class TestAsync__aenter__(object):
     # TODO: What do I need to do here
     @pytest.mark.asyncio
     async def test_basic_usage(self):
         user = AsyncUser("Alice", 25)
-        allow(user).__enter__.and_return(user)
+        allow(user).__aenter__.and_return(user)
 
-        with user as u:
-            assert (await user) == u
+        async with user as u:
+            assert user == u
 
     @pytest.mark.asyncio
     async def test_stubbing_two_objects_does_not_interfere(self):
         alice = AsyncUser("Alice", 25)
         bob = AsyncUser("Bob", 25)
 
-        allow(alice).__enter__.and_return("alice")
-        allow(bob).__enter__.and_return("bob")
+        allow(alice).__aenter__.and_return("alice")
+        allow(bob).__aenter__.and_return("bob")
 
-        with alice as a:
-            assert (await a) == "alice"
+        async with alice as a:
+            assert a == "alice"
 
-        with bob as b:
-            assert (await b) == "bob"
+        async with bob as b:
+            assert b == "bob"
 
     @pytest.mark.asyncio
     async def test_does_not_intefere_with_unstubbed_objects(self):
         alice = AsyncUser("Alice", 25)
         bob = AsyncUser("Bob", 25)
 
-        allow(alice).__enter__.and_return("user")
+        allow(alice).__aenter__.and_return("user")
 
-        with alice as a:
-            assert (await a) == "user"
+        async with alice as a:
+            assert a == "user"
 
-        with bob as b:
-            assert (await b) == bob
+        async with bob as b:
+            assert b == bob
 
     @pytest.mark.asyncio
     async def test_teardown_restores_previous_functionality(self):
         user = AsyncUser("Alice", 25)
-        allow(user).__enter__.and_return("bob barker")
+        allow(user).__aenter__.and_return("bob barker")
 
-        with user as u:
-            assert (await u) == "bob barker"
+        async with user as u:
+            assert u == "bob barker"
 
         teardown()
 
-        with user as u:
-            assert (await u) == user
+        async with user as u:
+            assert u == user
 
     @pytest.mark.asyncio
     async def test_raises_when_mocked_with_invalid_call_signature(self):
         user = AsyncUser("Alice", 25)
         with raises(VerifyingDoubleArgumentError):
-            allow(user).__enter__.with_args(1)
+            allow(user).__aenter__.with_args(1)
 
 
-class TestAsync__exit__(object):
+class TestAsync__aexit__(object):
     @pytest.mark.asyncio
     async def test_basic_usage(self):
         user = AsyncUser("Alice", 25)
-        allow(user).__exit__.with_args(None, None, None)
+        allow(user).__aexit__.with_args(None, None, None)
 
-        with user:
+        async with user:
             pass
 
     @pytest.mark.asyncio
@@ -189,38 +189,38 @@ class TestAsync__exit__(object):
         alice = AsyncUser("Alice", 25)
         bob = AsyncUser("Bob", 25)
 
-        allow(alice).__exit__.and_return("alice")
-        allow(bob).__exit__.and_return("bob")
+        allow(alice).__aexit__.and_return("alice")
+        allow(bob).__aexit__.and_return("bob")
 
-        assert (await alice.__exit__(None, None, None)) == "alice"
-        assert (await bob.__exit__(None, None, None)) == "bob"
+        assert (await alice.__aexit__(None, None, None)) == "alice"
+        assert (await bob.__aexit__(None, None, None)) == "bob"
 
     @pytest.mark.asyncio
     async def test_does_not_intefere_with_unstubbed_objects(self):
         alice = AsyncUser("Alice", 25)
         bob = AsyncUser("Bob", 25)
 
-        allow(alice).__exit__.and_return("user")
+        allow(alice).__aexit__.and_return("user")
 
-        assert (await alice.__exit__(None, None, None)) == "user"
-        assert (await bob.__exit__(None, None, None)) is None
+        assert (await alice.__aexit__(None, None, None)) == "user"
+        assert (await bob.__aexit__(None, None, None)) is None
 
     @pytest.mark.asyncio
     async def test_teardown_restores_previous_functionality(self):
         user = AsyncUser("Alice", 25)
-        allow(user).__exit__.and_return("bob barker")
+        allow(user).__aexit__.and_return("bob barker")
 
-        assert (await user.__exit__(None, None, None)) == "bob barker"
+        assert (await user.__aexit__(None, None, None)) == "bob barker"
 
         teardown()
 
-        assert (await user.__exit__(None, None, None)) is None
+        assert (await user.__aexit__(None, None, None)) is None
 
     @pytest.mark.asyncio
     async def test_raises_when_mocked_with_invalid_call_signature(self):
         user = AsyncUser("Alice", 25)
         with raises(VerifyingDoubleArgumentError):
-            allow(user).__exit__.with_no_args()
+            allow(user).__aexit__.with_no_args()
 
 
 class TestAsyncClassMethods(object):

--- a/test/async_partial_double_test.py
+++ b/test/async_partial_double_test.py
@@ -1,0 +1,319 @@
+import pytest
+from pytest import raises
+
+import dobles.testing
+from dobles import allow
+from dobles.exceptions import (
+    UnallowedMethodCallError,
+    VerifyingDoubleArgumentError,
+    VerifyingDoubleError,
+)
+from dobles.lifecycle import teardown
+from dobles.testing import AsyncUser
+
+
+class TestAsyncInstanceMethods(object):
+    @pytest.mark.asyncio
+    async def test_arbitrary_callable_on_instance(self):
+        instance = AsyncUser("Bob", 10)
+        allow(instance).arbitrary_callable.and_return("Bob Barker")
+        assert (await instance.arbitrary_callable()) == "Bob Barker"
+        teardown()
+        assert (await instance.arbitrary_callable()) == "ArbitraryCallable Value"
+
+    @pytest.mark.asyncio
+    async def test_arbitrary_callable_on_class(self):
+        allow(AsyncUser).arbitrary_callable.and_return("Bob Barker")
+        assert (await AsyncUser.arbitrary_callable()) == "Bob Barker"
+        teardown()
+        assert (await AsyncUser.arbitrary_callable()) == "ArbitraryCallable Value"
+
+    @pytest.mark.asyncio
+    async def test_callable_class_attribute(self):
+        allow(AsyncUser).callable_class_attribute.and_return("Bob Barker")
+        assert (await AsyncUser.callable_class_attribute()) == "Bob Barker"
+        teardown()
+        assert (await AsyncUser.callable_class_attribute()) == "dummy result"
+
+    @pytest.mark.asyncio
+    async def test_callable_instance_attribute(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).callable_instance_attribute.and_return("Bob Barker")
+
+        assert (await user.callable_instance_attribute()) == "Bob Barker"
+        teardown()
+        assert (await user.callable_instance_attribute()) == "dummy result"
+
+    @pytest.mark.asyncio
+    async def test_stubs_instance_methods(self):
+        user = AsyncUser("Alice", 25)
+
+        allow(user).get_name.and_return("Bob")
+
+        assert (await user.get_name()) == "Bob"
+
+    @pytest.mark.asyncio
+    async def test_restores_instance_methods_on_teardown(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).get_name.and_return("Bob")
+
+        teardown()
+
+        assert (await user.get_name()) == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_only_affects_stubbed_method(self):
+        user = AsyncUser("Alice", 25)
+
+        allow(user).get_name.and_return("Bob")
+
+        assert user.age == 25
+
+    @pytest.mark.asyncio
+    async def test_raises_when_stubbing_nonexistent_methods(self):
+        user = AsyncUser("Alice", 25)
+
+        with raises(VerifyingDoubleError):
+            allow(user).gender
+
+
+class TestAsync__call__(object):
+    @pytest.mark.asyncio
+    async def test_basic_usage(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__call__.and_return("bob barker")
+
+        assert (await user()) == "bob barker"
+
+    @pytest.mark.asyncio
+    async def test_stubbing_two_objects_does_not_interfere(self):
+        alice = AsyncUser("Alice", 25)
+        peter = AsyncUser("Peter", 25)
+
+        allow(alice).__call__.and_return("alice")
+        allow(peter).__call__.and_return("peter")
+
+        assert (await alice()) == "alice"
+        assert (await peter()) == "peter"
+
+    @pytest.mark.asyncio
+    async def test_works_with_arguments(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__call__.with_args(1, 2).and_return("bob barker")
+
+        assert (await user(1, 2)) == "bob barker"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_called_with_invalid_args(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__call__.with_args(1, 2).and_return("bob barker")
+
+        with raises(UnallowedMethodCallError):
+            await user(1, 2, 3)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_mocked_with_invalid_call_signature(self):
+        user = AsyncUser("Alice", 25)
+        with raises(VerifyingDoubleArgumentError):
+            await allow(user).__call__.with_args(1, 2, bob="barker")
+
+
+class TestAsync__enter__(object):
+    # TODO: What do I need to do here
+    @pytest.mark.asyncio
+    async def test_basic_usage(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__enter__.and_return(user)
+
+        with user as u:
+            assert (await user) == u
+
+    @pytest.mark.asyncio
+    async def test_stubbing_two_objects_does_not_interfere(self):
+        alice = AsyncUser("Alice", 25)
+        bob = AsyncUser("Bob", 25)
+
+        allow(alice).__enter__.and_return("alice")
+        allow(bob).__enter__.and_return("bob")
+
+        with alice as a:
+            assert (await a) == "alice"
+
+        with bob as b:
+            assert (await b) == "bob"
+
+    @pytest.mark.asyncio
+    async def test_does_not_intefere_with_unstubbed_objects(self):
+        alice = AsyncUser("Alice", 25)
+        bob = AsyncUser("Bob", 25)
+
+        allow(alice).__enter__.and_return("user")
+
+        with alice as a:
+            assert (await a) == "user"
+
+        with bob as b:
+            assert (await b) == bob
+
+    @pytest.mark.asyncio
+    async def test_teardown_restores_previous_functionality(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__enter__.and_return("bob barker")
+
+        with user as u:
+            assert (await u) == "bob barker"
+
+        teardown()
+
+        with user as u:
+            assert (await u) == user
+
+    @pytest.mark.asyncio
+    async def test_raises_when_mocked_with_invalid_call_signature(self):
+        user = AsyncUser("Alice", 25)
+        with raises(VerifyingDoubleArgumentError):
+            allow(user).__enter__.with_args(1)
+
+
+class TestAsync__exit__(object):
+    @pytest.mark.asyncio
+    async def test_basic_usage(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__exit__.with_args(None, None, None)
+
+        with user:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_stubbing_two_objects_does_not_interfere(self):
+        alice = AsyncUser("Alice", 25)
+        bob = AsyncUser("Bob", 25)
+
+        allow(alice).__exit__.and_return("alice")
+        allow(bob).__exit__.and_return("bob")
+
+        assert (await alice.__exit__(None, None, None)) == "alice"
+        assert (await bob.__exit__(None, None, None)) == "bob"
+
+    @pytest.mark.asyncio
+    async def test_does_not_intefere_with_unstubbed_objects(self):
+        alice = AsyncUser("Alice", 25)
+        bob = AsyncUser("Bob", 25)
+
+        allow(alice).__exit__.and_return("user")
+
+        assert (await alice.__exit__(None, None, None)) == "user"
+        assert (await bob.__exit__(None, None, None)) is None
+
+    @pytest.mark.asyncio
+    async def test_teardown_restores_previous_functionality(self):
+        user = AsyncUser("Alice", 25)
+        allow(user).__exit__.and_return("bob barker")
+
+        assert (await user.__exit__(None, None, None)) == "bob barker"
+
+        teardown()
+
+        assert (await user.__exit__(None, None, None)) is None
+
+    @pytest.mark.asyncio
+    async def test_raises_when_mocked_with_invalid_call_signature(self):
+        user = AsyncUser("Alice", 25)
+        with raises(VerifyingDoubleArgumentError):
+            allow(user).__exit__.with_no_args()
+
+
+class TestAsyncClassMethods(object):
+    @pytest.mark.asyncio
+    async def test_stubs_class_methods(self):
+        allow(AsyncUser).class_method.with_args("foo").and_return("overridden value")
+
+        assert (await AsyncUser.class_method("foo")) == "overridden value"
+
+    @pytest.mark.asyncio
+    async def test_restores_class_methods_on_teardown(self):
+        allow(AsyncUser).class_method.and_return("overridden value")
+
+        teardown()
+
+        assert (await AsyncUser.class_method("foo")) == "class_method return value: foo"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_stubbing_noncallable_attributes(self):
+        with raises(VerifyingDoubleError):
+            allow(AsyncUser).class_attribute
+
+    @pytest.mark.asyncio
+    async def test_raises_when_stubbing_nonexistent_class_methods(self):
+        with raises(VerifyingDoubleError):
+            allow(AsyncUser).nonexistent_method
+
+
+class TestTopLevelFunctions(object):
+    @pytest.mark.asyncio
+    async def test_stubs_method(self):
+        allow(dobles.testing).async_top_level_function.and_return("foo")
+
+        assert (await dobles.testing.async_top_level_function("bob barker")) == "foo"
+
+    @pytest.mark.asyncio
+    async def test_restores_the_orignal_method(self):
+        allow(dobles.testing).async_top_level_function.and_return("foo")
+        teardown()
+        assert (
+            await dobles.testing.async_top_level_function("foo", "bar")
+        ) == "foo -- bar"
+
+    @pytest.mark.asyncio
+    async def test_raises_if_incorrect_call_signature_used(self):
+        with raises(VerifyingDoubleArgumentError):
+            allow(dobles.testing).async_top_level_function.with_args(
+                "bob", "barker", "is_great"
+            )
+
+    @pytest.mark.asyncio
+    async def test_allows_correct_call_signature(self):
+        allow(dobles.testing).async_top_level_function.with_args(
+            "bob",
+            "barker",
+        ).and_return("bar")
+        # assert (await dobles.testing.async_top_level_function("bob", "barker")) == "bar"
+
+    @pytest.mark.asyncio
+    async def test_verifies_the_function_exists(self):
+        with raises(VerifyingDoubleError):
+            allow(dobles.testing).fake_function
+
+    @pytest.mark.asyncio
+    async def test_callable_top_level_variable(self):
+        allow(dobles.testing).async_callable_variable.and_return("foo")
+
+        assert (await dobles.testing.async_callable_variable("bob barker")) == "foo"
+
+    @pytest.mark.asyncio
+    async def test_decorated_function(self):
+        allow(dobles.testing).async_decorated_function_callable.and_return("foo")
+
+        assert (
+            await dobles.testing.async_decorated_function_callable("bob barker")
+        ) == "foo"
+
+    @pytest.mark.asyncio
+    async def test_decorated_function_that_returns_a_callable(self):
+        allow(dobles.testing).async_decorated_function_callable.and_return("foo")
+
+        assert (
+            await dobles.testing.async_decorated_function_callable("bob barker")
+        ) == "foo"
+
+    @pytest.mark.asyncio
+    async def test_variable_that_points_to_class_method(self):
+        allow(dobles.testing).async_class_method("bob barker").and_return("foo")
+
+        assert (await dobles.testing.async_class_method("bob barker")) == "foo"
+
+    @pytest.mark.asyncio
+    async def test_variable_that_points_to_instance_method(self):
+        allow(dobles.testing).async_instance_method.and_return("foo")
+
+        assert (await dobles.testing.async_instance_method()) == "foo"

--- a/test/partial_double_test.py
+++ b/test/partial_double_test.py
@@ -1,3 +1,5 @@
+from pytest import raises
+
 import dobles.testing
 from dobles import allow, no_builtin_verification
 from dobles.exceptions import (
@@ -7,7 +9,6 @@ from dobles.exceptions import (
 )
 from dobles.lifecycle import teardown
 from dobles.testing import User, UserWithCustomNew
-from pytest import raises
 
 
 class TestInstanceMethods(object):


### PR DESCRIPTION
* Remove `and_return_future` and `and_raise_future`
* Inspect doubled method and if it is async update return_value to be a coroutine so it can be awaited
* Bump to version 3 since it is a breaking change.