### PR TITLE
[WIP] Don't disregard all type hints...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: test
 test: clean lint
-	@py.test -s -p no:dobles test
+	poetry run py.test -s -p no:dobles test
 
 .PHONY: lint
 lint:
-	@flake8 --extend-ignore E501 dobles test
-	@black . 
+	poetry run flake8 --extend-ignore E501 dobles test
+	poetry run black .
 
 .PHONY: clean
 clean:

--- a/dobles/target.py
+++ b/dobles/target.py
@@ -185,4 +185,6 @@ class Target(object):
                     object = getattr(object, i)
                     break
 
-        return iscoroutinefunction(object)
+        if iscoroutinefunction(object):
+            return True
+

--- a/dobles/testing.py
+++ b/dobles/testing.py
@@ -174,6 +174,15 @@ class AsyncCallable(object):
         return arg1
 
 
+class Awaitable(object):
+    def __await__(self):
+        return self
+
+
+def fake_async_function() -> Awaitable:
+    return Awaitable()
+
+
 def return_callable(func):
     return Callable()
 

--- a/test/async_partial_double_test.py
+++ b/test/async_partial_double_test.py
@@ -185,6 +185,13 @@ class TestAsync__aenter__(object):
             allow(user).__aenter__.with_args(1)
 
 
+class TestFakeAwaitable(object):
+    @pytest.mark.asyncio
+    async def test_fake_awaitable(self):
+        allow(dobles.testing).fake_async_function().and_return("house")
+        assert (await dobles.testing.fake_async_function()) == "house"
+
+
 class TestAsync__aexit__(object):
     @pytest.mark.asyncio
     async def test_basic_usage(self):

--- a/test/partial_double_test.py
+++ b/test/partial_double_test.py
@@ -271,6 +271,13 @@ class Test__exit__(object):
 
 class TestClassMethods(object):
     def test_stubs_class_methods(self):
+        allow(dobles.testing.User).class_method.with_args("foo").and_return(
+            "overridden value"
+        )
+
+        assert User.class_method("foo") == "overridden value"
+
+    def test_stubs_class_methods_str(self):
         allow("dobles.testing.User").class_method.with_args("foo").and_return(
             "overridden value"
         )
@@ -338,6 +345,11 @@ class TestCustomConstructorMethods(object):
 
 class TestTopLevelFunctions(object):
     def test_stubs_method(self):
+        allow(dobles.testing).top_level_function.and_return("foo")
+
+        assert dobles.testing.top_level_function("bob barker") == "foo"
+
+    def test_stubs_method_str(self):
         allow("dobles.testing").top_level_function.and_return("foo")
 
         assert dobles.testing.top_level_function("bob barker") == "foo"


### PR DESCRIPTION
This is my first attempt at looking at mypy types at all. 

I ran into an issue trying to mock aiohttp.ClientSession.post; because it is not an async function....it returns an obejct that implements `await`.  I don't think there is anyway to identify that other than looking at the types. 

I was able to get around it by doing:
     

    session = InstanceDouble("aiohttp.ClientSession")
    expect(session).__aenter__().and_return(session)
    allow(session).__aexit__
    expect(push_notification.aiohttp).ClientSession().and_return(session)
    async def response():
        return SimpleNamespace(ok=True)

    expect(session).post(
        url=subscription.endpoint,
        data="encrypted",
        headers={"header": "t"}
    ).and_return(
        response()
    )
    
Which leaves plenty of room for improvement :) 